### PR TITLE
Apps

### DIFF
--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -1,0 +1,35 @@
+Advanced
+==========
+<a id="advanced"> </a>
+
+<a id="extending_cytoscape_web"> </a>
+## Extending Cytoscape Web
+
+**Apps** and **Service-Apps** are community built additions that add new functionality to 
+Cytoscape Web. 
+
+ Writing an **[App](Advanced#app)** (written in Typescript) gives the developer the
+most access to Cytoscape Web APIs and user interface to extend
+or augment the interface and analysis tools, but requires comfort
+in web development.
+
+The **[Service-Apps](Advanced#service_app)** are more limited in accessibility, but are easier
+ to implement and offer freedom of language. 
+
+<a id="app"> </a>
+### App
+
+Coming soon
+
+<a id="service_app"> </a>
+### Service-App
+
+A Service-App is a REST service that can be registered with Cytoscape Web to extend
+functionality. For more information about creating a Service-App see:
+
+[Cytoscape Web Service-App REST service V1 specification](https://github.com/cytoscape/cytoscape-web/wiki/Specification-for-Service%E2%80%90based-App-in-Cytoscape-Web-(draft-v2))
+
+
+
+
+

--- a/docs/Extending.md
+++ b/docs/Extending.md
@@ -1,9 +1,7 @@
-Advanced
-==========
-<a id="advanced"> </a>
-
+Extending Cytoscape Web
+=========================
 <a id="extending_cytoscape_web"> </a>
-## Extending Cytoscape Web
+
 
 **Apps** and **Service-Apps** are community built additions that add new functionality to 
 Cytoscape Web. 
@@ -17,12 +15,15 @@ The **[Service-Apps](Advanced#service_app)** are more limited in accessibility, 
  to implement and offer freedom of language. 
 
 <a id="app"> </a>
-### App
+## App
 
-Coming soon
+[Documentation to build an App](https://github.com/cytoscape/cytoscape-web-app-examples/tree/pre-release-cleanup)
+
+For integration of a custom App into Cytoscape Web please contact us (TODO ADD CONTACT)
+
 
 <a id="service_app"> </a>
-### Service-App
+## Service-App
 
 A Service-App is a REST service that can be registered with Cytoscape Web to extend
 functionality. For more information about creating a Service-App see:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Copyright (c) 2001-2024 The Cytoscape Consortium
    Styles
    Merge
    Export_Your_Data
+   Advanced
    Cytoscape_Privacy_Policy
 ..
    

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Copyright (c) 2001-2024 The Cytoscape Consortium
    Styles
    Merge
    Export_Your_Data
-   Advanced
+   Extending
    Cytoscape_Privacy_Policy
 ..
    


### PR DESCRIPTION
I was looking to add documentation about App development and Service-App development to the manual in the `apps` branch I added an Advanced.md and put some documentation about Apps and Service-Apps. The Service-App has a link to our wiki docs (still a work in progress). If this makes sense please merge in otherwise suggest how we should incorporate this more advanced documentation.

thanks