### PR TITLE
Fixed dynamic copyright notice in cyweb's manual index page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ master_doc = 'index'
 
 from datetime import datetime
 current_year = datetime.now().year
-copyright = f'&copy; 2001-{current_year}, The Cytoscape Consortium.' # u'2001-{}, The Cytoscape Consortium'.format(current_year)
+copyright = u'2001-{}, The Cytoscape Consortium'.format(current_year)    # f'© 2001-{current_year}, The Cytoscape Consortium'
 project = u'Cytoscape Web User Manual'
 author = u'The Cytoscape Consortium'
 
@@ -14,7 +14,7 @@ release = '1.0.x'
 language = None
 
 rst_epilog = f"""
-.. |index_copyright| replace:: &copy; 2001-{current_year}, The Cytoscape Consortium.
+.. |index_copyright| replace:: © 2001-{current_year}, The Cytoscape Consortium.
 """
 
 exclude_patterns = ['_build']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,13 +1,12 @@
-from datetime import datetime
-
 extensions = []
 templates_path = ['_templates']
 
 master_doc = 'index'
 
+from datetime import datetime
 current_year = datetime.now().year
-project = u'Cytoscape Web User Manual'
 copyright = u'2001-{}, The Cytoscape Consortium'.format(current_year)
+project = u'Cytoscape Web User Manual'
 author = u'The Cytoscape Consortium'
 
 version = '1.0.x'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ release = '1.0.x'
 language = None
 
 rst_epilog = f"""
-.. |index_copyright| replace:: © 2001-{current_year}, The Cytoscape Consortium.
+.. |index_copyright| replace:: © Copyright 2001-{current_year}, The Cytoscape Consortium.
 """
 
 exclude_patterns = ['_build']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,10 @@ version = '1.0.x'
 release = '1.0.x'
 language = None
 
+rst_epilog = """
+.. |index_copyright| replace:: u'2001-{}, The Cytoscape Consortium'.format(current_year)
+"""
+
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ master_doc = 'index'
 
 from datetime import datetime
 current_year = datetime.now().year
-copyright = u'2001-{}, The Cytoscape Consortium'.format(current_year)
+copyright = f'&copy; 2001-{current_year}, The Cytoscape Consortium.' # u'2001-{}, The Cytoscape Consortium'.format(current_year)
 project = u'Cytoscape Web User Manual'
 author = u'The Cytoscape Consortium'
 
@@ -13,8 +13,8 @@ version = '1.0.x'
 release = '1.0.x'
 language = None
 
-rst_epilog = """
-.. |index_copyright| replace:: u'2001-{}, The Cytoscape Consortium'.format(current_year)
+rst_epilog = f"""
+.. |index_copyright| replace:: &copy; 2001-{current_year}, The Cytoscape Consortium.
 """
 
 exclude_patterns = ['_build']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ master_doc = 'index'
 
 current_year = datetime.now().year
 project = u'Cytoscape Web User Manual'
-copyright = u'2001-'{}', The Cytoscape Consortium'.format(current_year)
+copyright = u'2001-{}, The Cytoscape Consortium.'.format(current_year)
 author = u'The Cytoscape Consortium'
 
 version = '1.0.x'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ master_doc = 'index'
 
 current_year = datetime.now().year
 project = u'Cytoscape Web User Manual'
-copyright = u'2001-{}, The Cytoscape Consortium.'.format(current_year)
+copyright = u'2001-{}, The Cytoscape Consortium'.format(current_year)
 author = u'The Cytoscape Consortium'
 
 version = '1.0.x'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Cytoscape itself: LGPL 2.1, the GNU Lesser General Public License,
 version 2.1, February 1999 available in text at
 http://www.gnu.org/licenses/lgpl-2.1.html.
 
-Copyright |index_copyright|
+|index_copyright|
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Cytoscape itself: LGPL 2.1, the GNU Lesser General Public License,
 version 2.1, February 1999 available in text at
 http://www.gnu.org/licenses/lgpl-2.1.html.
 
-Copyright |copyright|
+Copyright |index_copyright|
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Configured new custom variable (index_copyright) in conf.py using:

`rst_epilog = f"""
.. |index_copyright| replace:: © Copyright 2001-{current_year}, The Cytoscape Consortium.
"""`
and then used |index_copyright| in index.rst to include copyright info in manual's index page